### PR TITLE
Add dbt-labs/audit_helper + dbt-labs/dbt_external_tables

### DIFF
--- a/data/packages/dbt-labs/audit_helper/index.json
+++ b/data/packages/dbt-labs/audit_helper/index.json
@@ -1,0 +1,9 @@
+{
+    "name": "audit_helper",
+    "namespace": "dbt-labs",
+    "description": "dbt models for dbt-audit-helper",
+    "latest": "0.3.0",
+    "assets": {
+        "logo": "logos/placeholder.svg"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.0.1.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.0.1.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.0.1",
+    "name": "audit_helper",
+    "version": "0.0.1",
+    "published_at": "2019-07-11T00:17:20.119034+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.2.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.0.1/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.0.1/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.0.1",
+        "format": "tgz",
+        "sha1": "86f468a02640fb892a81c8c1e960cef6b5bc44a0"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.0.2.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.0.2.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.0.2",
+    "name": "audit_helper",
+    "version": "0.0.2",
+    "published_at": "2019-08-15T01:00:03.890099+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.3.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.0.2/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.0.2/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.0.2",
+        "format": "tgz",
+        "sha1": "7b91a3d72ca2dc110e45fc13fb8041610ca3ad23"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.0.6.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.0.6.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.0.6",
+    "name": "audit_helper",
+    "version": "0.0.6",
+    "published_at": "2020-04-27T16:00:08.692323+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.4.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.0.6/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.0.6/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.0.6",
+        "format": "tgz",
+        "sha1": "6464f7158add2654e20a28293903f3dd4889c155"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.1.0.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.1.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.1.0",
+    "name": "audit_helper",
+    "version": "0.1.0",
+    "published_at": "2020-06-16T14:03:19.640267+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.5.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.1.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.1.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.1.0",
+        "format": "tgz",
+        "sha1": "f45abed0b4bea322a25f3329d82eb1df585a147c"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.2.0.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.2.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.2.0",
+    "name": "audit_helper",
+    "version": "0.2.0",
+    "published_at": "2020-07-31T15:03:05.795835+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.6.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.2.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.2.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.2.0",
+        "format": "tgz",
+        "sha1": "27122069f1bc1a9f86768c26253c536f0073854f"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/0.3.0.json
+++ b/data/packages/dbt-labs/audit_helper/versions/0.3.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/0.3.0",
+    "name": "audit_helper",
+    "version": "0.3.0",
+    "published_at": "2020-09-04T21:01:57.323495+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/0.3.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/0.3.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/0.3.0",
+        "format": "tgz",
+        "sha1": "28cfded1d163cf071d1f23d25b13133fa78639bd"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/v0.0.3.json
+++ b/data/packages/dbt-labs/audit_helper/versions/v0.0.3.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/v0.0.3",
+    "name": "audit_helper",
+    "version": "v0.0.3",
+    "published_at": "2019-10-02T23:00:03.010257+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.3.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/v0.0.3/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/v0.0.3/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/v0.0.3",
+        "format": "tgz",
+        "sha1": "3a35fe36eaec69ce1d80d8e41e799fd01d920857"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/v0.0.4.json
+++ b/data/packages/dbt-labs/audit_helper/versions/v0.0.4.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/v0.0.4",
+    "name": "audit_helper",
+    "version": "v0.0.4",
+    "published_at": "2019-10-03T01:00:03.738744+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.3.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/v0.0.4/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/v0.0.4/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/v0.0.4",
+        "format": "tgz",
+        "sha1": "0894412fb038bb875dc23975e91e7cee4bd831e7"
+    }
+}

--- a/data/packages/dbt-labs/audit_helper/versions/v0.0.5.json
+++ b/data/packages/dbt-labs/audit_helper/versions/v0.0.5.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/audit_helper/v0.0.5",
+    "name": "audit_helper",
+    "version": "v0.0.5",
+    "published_at": "2020-04-06T19:00:05.872013+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.1.24",
+                "<0.3.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-audit-helper/tree/v0.0.5/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-audit-helper/v0.0.5/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-audit-helper/tar.gz/v0.0.5",
+        "format": "tgz",
+        "sha1": "234224f6b46a84753a502cacacc45bfff3d08d07"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/index.json
+++ b/data/packages/dbt-labs/dbt_external_tables/index.json
@@ -1,0 +1,9 @@
+{
+    "name": "dbt_external_tables",
+    "namespace": "dbt-labs",
+    "description": "dbt models for dbt-external-tables",
+    "latest": "0.6.3",
+    "assets": {
+        "logo": "logos/placeholder.svg"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.1.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.1.0.json
@@ -1,0 +1,18 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.1.0",
+    "name": "dbt_external_tables",
+    "version": "0.1.0",
+    "published_at": "2019-11-27T15:10:43.224028+00:00",
+    "packages": [],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.1.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.1.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.1.0",
+        "format": "tgz",
+        "sha1": "8de91e3c6c0ce4a79c3fcdf574c44feeadd4e30e"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.1.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.1.1.json
@@ -1,0 +1,18 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.1.1",
+    "name": "dbt_external_tables",
+    "version": "0.1.1",
+    "published_at": "2020-01-21T19:00:04.043858+00:00",
+    "packages": [],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.1.1/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.1.1/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.1.1",
+        "format": "tgz",
+        "sha1": "ef26c845707f7cc04ed7a84455d1ebe105e6abdd"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.1.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.1.2.json
@@ -1,0 +1,18 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.1.2",
+    "name": "dbt_external_tables",
+    "version": "0.1.2",
+    "published_at": "2020-03-30T17:00:05.666465+00:00",
+    "packages": [],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.1.2/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.1.2/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.1.2",
+        "format": "tgz",
+        "sha1": "cf9ad60edc2de50191a42e8999f2422c5769300e"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.1.3.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.1.3.json
@@ -1,0 +1,18 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.1.3",
+    "name": "dbt_external_tables",
+    "version": "0.1.3",
+    "published_at": "2020-04-01T22:00:05.330089+00:00",
+    "packages": [],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.1.3/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.1.3/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.1.3",
+        "format": "tgz",
+        "sha1": "eec1365fd8191bb34c2aac024f518304d43c5c1c"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.2.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.2.0.json
@@ -1,0 +1,23 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.2.0",
+    "name": "dbt_external_tables",
+    "version": "0.2.0",
+    "published_at": "2020-05-07T21:00:05.974853+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": ">=0.1.25"
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.2.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.2.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.2.0",
+        "format": "tgz",
+        "sha1": "880bfc314df3faf0dece66a39ddbf479cd0aafba"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.3.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.3.0.json
@@ -1,0 +1,23 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.3.0",
+    "name": "dbt_external_tables",
+    "version": "0.3.0",
+    "published_at": "2020-06-10T19:00:52.719156+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": ">=0.1.25"
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.3.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.3.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.3.0",
+        "format": "tgz",
+        "sha1": "1961a8117d64cc3d063d6a0cf678aa059e74d40b"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.3.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.3.1.json
@@ -1,0 +1,23 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.3.1",
+    "name": "dbt_external_tables",
+    "version": "0.3.1",
+    "published_at": "2020-07-07T20:02:26.245705+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": ">=0.1.25"
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.3.1/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.3.1/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.3.1",
+        "format": "tgz",
+        "sha1": "856ccc6dc4d9899ea41e05ad00516d7a5989c43e"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.3.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.3.2.json
@@ -1,0 +1,23 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.3.2",
+    "name": "dbt_external_tables",
+    "version": "0.3.2",
+    "published_at": "2020-07-29T17:01:03.298523+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": ">=0.1.25"
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.3.2/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.3.2/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.3.2",
+        "format": "tgz",
+        "sha1": "14a4b67bbb29a31ef08fc2e4b0f7dc112deeb22d"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.4.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.4.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.4.0",
+    "name": "dbt_external_tables",
+    "version": "0.4.0",
+    "published_at": "2020-07-31T19:01:52.747001+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.4.0",
+                "<0.6.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.4.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.4.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.4.0",
+        "format": "tgz",
+        "sha1": "34ea245587e15421b5482e94810f30315299bbbc"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.5.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.5.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.5.0",
+    "name": "dbt_external_tables",
+    "version": "0.5.0",
+    "published_at": "2020-09-04T21:01:57.323495+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.5.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.5.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.5.0",
+        "format": "tgz",
+        "sha1": "3b751a896f61bf9602973063de9c1b04b964271b"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.6.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.6.0.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.6.0",
+    "name": "dbt_external_tables",
+    "version": "0.6.0",
+    "published_at": "2020-12-03T20:02:43.686607+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.6.0/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.6.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.6.0",
+        "format": "tgz",
+        "sha1": "4c62ba77570a40b34eb115b9b02fe830a2509c84"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.6.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.6.1.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.6.1",
+    "name": "dbt_external_tables",
+    "version": "0.6.1",
+    "published_at": "2021-01-06T12:02:14.814255+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.6.1/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.6.1/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.6.1",
+        "format": "tgz",
+        "sha1": "867c30221b19fb1613ca19bf597a162dc08b17ee"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.6.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.6.2.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.6.2",
+    "name": "dbt_external_tables",
+    "version": "0.6.2",
+    "published_at": "2021-01-28T20:01:30.800112+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.6.2/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.6.2/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.6.2",
+        "format": "tgz",
+        "sha1": "56b3665be60d25d419b071bcd44b396b25497281"
+    }
+}

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.6.3.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.6.3.json
@@ -1,0 +1,26 @@
+{
+    "id": "dbt-labs/dbt_external_tables/0.6.3",
+    "name": "dbt_external_tables",
+    "version": "0.6.3",
+    "published_at": "2021-05-25T05:03:22.853109+00:00",
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/dbt-labs/dbt-external-tables/tree/0.6.3/",
+        "readme": "https://raw.githubusercontent.com/dbt-labs/dbt-external-tables/0.6.3/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/dbt-labs/dbt-external-tables/tar.gz/0.6.3",
+        "format": "tgz",
+        "sha1": "a93d02fd466939e48693b318373009ecdccab3eb"
+    }
+}


### PR DESCRIPTION
Hubcap missed these, I'm not sure why. I just copied from `fishtown-analytics/audit_helper` + `dbt-labs/dbt_external_tables`, and did find+replace for `fishtown-analytics` --> `dbt-labs`