### PR TITLE
Fix packages for fivetran_utils 0.2.0

### DIFF
--- a/data/packages/fivetran/fivetran_utils/versions/v0.2.0.json
+++ b/data/packages/fivetran/fivetran_utils/versions/v0.2.0.json
@@ -3,7 +3,15 @@
     "name": "fivetran_utils",
     "version": "v0.2.0",
     "published_at": "2021-07-14T07:02:02.347127+00:00",
-    "packages": [],
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.7.0",
+                "<0.8.0"
+            ]
+        }
+    ],
     "works_with": [],
     "_source": {
         "type": "github",


### PR DESCRIPTION
Follow-up to #686

See: https://github.com/fivetran/dbt_fivetran_utils/blob/v0.2.0/packages.yml

dbt-labs/hubcap#44 is still a problem