### PR TITLE
Fix packages for fivetran_utils 0.2.1

### DIFF
--- a/data/packages/fivetran/fivetran_utils/versions/v0.2.1.json
+++ b/data/packages/fivetran/fivetran_utils/versions/v0.2.1.json
@@ -3,7 +3,15 @@
     "name": "fivetran_utils",
     "version": "v0.2.1",
     "published_at": "2021-07-14T18:04:03.752087+00:00",
-    "packages": [],
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.7.0",
+                "<0.8.0"
+            ]
+        }
+    ],
     "works_with": [],
     "_source": {
         "type": "github",


### PR DESCRIPTION
Follow-up to #689

See: https://github.com/fivetran/dbt_fivetran_utils/blob/v0.2.1/packages.yml

dbt-labs/hubcap#44 is still a problem