### PR TITLE
Fix packages for fivetran-utils 0.2.3

### DIFF
--- a/data/packages/fivetran/fivetran_utils/versions/v0.2.3.json
+++ b/data/packages/fivetran/fivetran_utils/versions/v0.2.3.json
@@ -3,7 +3,15 @@
     "name": "fivetran_utils",
     "version": "v0.2.3",
     "published_at": "2021-07-16T22:03:30.457354+00:00",
-    "packages": [],
+    "packages": [
+        {
+            "package": "dbt-labs/dbt_utils",
+            "version": [
+                ">=0.7.0",
+                "<0.8.0"
+            ]
+        }
+    ],
     "works_with": [],
     "_source": {
         "type": "github",


### PR DESCRIPTION
Follow-up to #699

See: https://github.com/fivetran/dbt_fivetran_utils/blob/v0.2.3/packages.yml
Actually missing for v0.2.2, weirdly: https://github.com/fivetran/dbt_fivetran_utils/tree/v0.2.2. Looks like the release was removed after the fact, but the tag is still there.

dbt-labs/hubcap#44 is still a problem