### PR TITLE
Update _nav.erb to fix GH star button

### DIFF
--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -3,25 +3,29 @@
 	<div class="section-content">
 	  <div class="navigation-content" style="height: 80px">
 		<div class="navigation-brand">
-		  <a class="hub-logo" href="<%= site_url %>/" title="dbt hub" target="_self">
+		     <a class="hub-logo" href="<%= site_url %>/" title="dbt hub" target="_self">
 			<strong class="nav-logo-text">dbt hub</strong>
             		<img src='/images/logos/dbt-lockup.png' style="height: 48px"/>
 		  </a>
 		</div>
 		<div class="navigation-link">
-			<a class="github-button btn btn-blue btn-shadow" 
-			   href="https://github.com/dbt-labs/dbt" 
-			   data-icon="octicon-star" 
-			   data-size="large" 
-			   data-show-count="true" 
-			   aria-label="Star dbt-labs/dbt on GitHub">Star
+		     <a class="btn btn-blue btn-shadow"
+			href="https://github.com/dbt-labs/dbt"
+			target="_blank">
+			     <i class="github-button"
+				data-icon="octicon-star"
+				data-size="large"
+				data-show-count="true"
+				aria-label="Star dbt-labs/dbt on GitHub"></i>
+			     GitHub
 			</a>
 		</div>
 		<div class="navigation-link">
-		  <a class="btn btn-blue btn-shadow"
-		     href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"
-		     target="_blank">
-		     <i data-icon="book"></i>Get started</a>
+		     <a class="btn btn-blue btn-shadow"
+			href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"
+			target="_blank">
+			     <i data-icon="book"></i>Get started
+			</a>
 		</div>
 		<div class="navigation-menu">
 		  <div class="dropdown">
@@ -30,7 +34,7 @@
 			  <li><a href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"
                      target="_blank">Get started</a></li>
 			  <li><a href="https://github.com/fishtown-analytics/dbt"
-                     target="_blank">Github</a></li>
+                     target="_blank">GitHub</a></li>
 			</ul>
 		  </div>
 		</div>

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -9,7 +9,7 @@
 		  </a>
 		</div>
 		<div class="navigation-link">
-			<a class="github-button" 
+			<a class="github-button btn btn-blue btn-shadow" 
 			   href="https://github.com/dbt-labs/dbt" 
 			   data-icon="octicon-star" 
 			   data-size="large" 

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -5,23 +5,24 @@
 		<div class="navigation-brand">
 		  <a class="hub-logo" href="<%= site_url %>/" title="dbt hub" target="_self">
 			<strong class="nav-logo-text">dbt hub</strong>
-            <img src='/images/logos/dbt-lockup.png' style="height: 48px"/>
+            		<img src='/images/logos/dbt-lockup.png' style="height: 48px"/>
 		  </a>
 		</div>
 		<div class="navigation-link">
-          <a class="github-button"
-             href="https://github.com/fishtown-analytics/dbt"
-             data-icon="octicon-star"
-             data-size="large"
-             data-show-count="true"
-             aria-label="Star dbt on GitHub">Github</a>
-        </div>
+			<a class="github-button" 
+			   href="https://github.com/dbt-labs/dbt" 
+			   data-icon="octicon-star" 
+			   data-size="large" 
+			   data-show-count="true" 
+			   aria-label="Star dbt-labs/dbt on GitHub">Star
+			</a>
+		</div>
 		<div class="navigation-link">
-          <a class="btn btn-blue btn-shadow"
-             href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"
-             target="_blank">
-             <i data-icon="book"></i>Get started</a>
-        </div>
+		  <a class="btn btn-blue btn-shadow"
+		     href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"
+		     target="_blank">
+		     <i data-icon="book"></i>Get started</a>
+		</div>
 		<div class="navigation-menu">
 		  <div class="dropdown">
 			<a class="btn btn-text btn-blue btn-skinny" href="#" data-toggle="dropdown"><i data-symbol="menu" class="lg"></i></a>

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -9,14 +9,14 @@
 		  </a>
 		</div>
 		<div class="navigation-link">
-		     <a class="btn btn-blue btn-shadow"
+		     <a class="btn btn-blue btn-shadow github-button"
 			href="https://github.com/dbt-labs/dbt"
+			data-icon="octoicon-star"
+			data-size="large"
+			data-show-count="true"
+			aria-label="Star dbt-labs/dbt on GitHub"
 			target="_blank">
-			     <i class="github-button"
-				data-icon="octicon-star"
-				data-size="large"
-				data-show-count="true"
-				aria-label="Star dbt-labs/dbt on GitHub"></i>
+			     <i data-icon="star"></i>
 			     GitHub
 			</a>
 		</div>

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -11,7 +11,6 @@
 		<div class="navigation-link">
 		     <a class="btn btn-blue btn-shadow github-button"
 			href="https://github.com/dbt-labs/dbt"
-			data-icon="octoicon-star"
 			data-size="large"
 			data-show-count="true"
 			aria-label="Star dbt-labs/dbt on GitHub"


### PR DESCRIPTION
Landing page banner currently looks like this following rename: 

<img width="218" alt="Screen Shot 2021-07-17 at 12 46 32 PM" src="https://user-images.githubusercontent.com/7892219/126047917-39883845-06fb-404e-8e79-e5b0744789ea.png">

Expected behavior: 
<img width="144" alt="Screen Shot 2021-07-17 at 12 47 05 PM" src="https://user-images.githubusercontent.com/7892219/126047925-535d517a-301a-4adc-a9e7-958b5c3bf2fb.png">

