### PR TITLE
Turn automerge back on

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,7 @@ on:
   check_suite:
     types: [ completed ]
 
-permissions: read-all
+permissions: write-all
   
   
 jobs:


### PR DESCRIPTION
Automerge was not respecting Netlify build status before merging. Repo settings have been changed to protect the master branch -- Netlify deploys must succeed before automerge kicks in 