### PR TITLE
Manually bump dbt expectations 0.4.1

### DIFF
--- a/data/packages/calogica/dbt_expectations/index.json
+++ b/data/packages/calogica/dbt_expectations/index.json
@@ -2,7 +2,7 @@
     "name": "dbt_expectations",
     "namespace": "calogica",
     "description": "dbt models for dbt-expectations",
-    "latest": "0.4.0",
+    "latest": "0.4.1",
     "assets": {
         "logo": "logos/placeholder.svg"
     }

--- a/data/packages/calogica/dbt_expectations/versions/0.4.1.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.4.1.json
@@ -2,7 +2,7 @@
     "id": "calogica/dbt_expectations/0.4.1",
     "name": "dbt_expectations",
     "version": "0.4.1",
-    "published_at": "2021-07-13T18:35:57.000000+00:00",
+    "published_at": "2021-07-24T06:52:57.000000+00:00",
     "packages": [
         {
             "package": "calogica/dbt_date",

--- a/data/packages/calogica/dbt_expectations/versions/0.4.1.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.4.1.json
@@ -1,0 +1,26 @@
+{
+    "id": "calogica/dbt_expectations/0.4.1",
+    "name": "dbt_expectations",
+    "version": "0.4.1",
+    "published_at": "2021-07-13T18:35:57.000000+00:00",
+    "packages": [
+        {
+            "package": "calogica/dbt_date",
+            "version": [
+                ">=0.4.0",
+                "<0.5.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/calogica/dbt-expectations/tree/0.4.1/",
+        "readme": "https://raw.githubusercontent.com/calogica/dbt-expectations/0.4.1/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/calogica/dbt-expectations/tar.gz/0.4.1",
+        "format": "tgz",
+        "sha1": "befff76b3cc720be411d7774be45882cae71d00a"
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/dbt-labs/hub.getdbt.com/issues/755 while long term fix is in the works. 