### PR TITLE
Add reference to docs for troubleshooting ruby version issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ git submodule update --init
 ```bash
 bundle install
 ```
+_If this fails, take a look at [this thread](https://gist.github.com/fernandoaleman/868b64cd60ab2d51ab24e7bf384da1ca#gistcomment-3082045)._
 
 ...and run with middleman:
 


### PR DESCRIPTION
On later Mac versions it may be necessary to upgrade Ruby to at least 2.7 and run some additional configuration before running bundle install. This PR just adds a note to the README with a link to a thread with troubleshooting advice. 