### PR TITLE
Make auto-merge less annoying

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,6 +23,6 @@ jobs:
         uses: pascalgn/automerge-action@v0.14.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: "automerge,!work in progress"
+          MERGE_LABELS: "automerge,!work in progress,!ready for review"
           MERGE_REMOVE_LABELS: "automerge"
           LOG: DEBUG

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,5 +23,6 @@ jobs:
         uses: pascalgn/automerge-action@v0.14.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: automerge
+          MERGE_LABELS: "automerge,!work in progress"
+          MERGE_REMOVE_LABELS: "automerge"
           LOG: DEBUG


### PR DESCRIPTION
If a ready for review or work in progress label is present, automerge will fail. This way a PR can wait on reviews before merge