### PR TITLE
Fix padding on mobile

### DIFF
--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -1,7 +1,7 @@
 <header class="header">
   <% if is_hidden(package, version) or (defined?(package.redirectnamespace) or defined?(package.redirectname)) %>
     <div class="row">
-      <div class="col-md-12 ">
+      <div class="col-md-12" style="padding:0px;">
         <%= partial "hidden" %>
       </div>
     </div>


### PR DESCRIPTION
There's a margin if you view the redirect banner on a small screen. This PR fixes this. 

Before: 
<img width="498" alt="Screen Shot 2021-08-24 at 10 37 30 PM" src="https://user-images.githubusercontent.com/7892219/130732556-adc95ec1-79d1-4ae2-ac61-6a27bb045db5.png">

After: 
<img width="498" alt="Screen Shot 2021-08-24 at 10 39 41 PM" src="https://user-images.githubusercontent.com/7892219/130732724-e501abfa-f533-40d5-9d91-57ba79ee5d57.png">
