### PR TITLE
Temporary disable of this workflow.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 # Add 'automerge' label to any change to package versions or contents
-automerge:
-- data/packages/**/*
+#automerge:
+#- data/packages/**/*


### PR DESCRIPTION
While we're testing dbt hubcap improvements, it's a prudent measure to disable this labeling. That way, don't have to go through a lot of reverting if errors pile up due to an error in the script which runs on the hour.