### PR TITLE
Revert "Temporary disable of this workflow."

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 # Add 'automerge' label to any change to package versions or contents
-#automerge:
-#- data/packages/**/*
+automerge:
+- data/packages/**/*


### PR DESCRIPTION
Reverts dbt-labs/hub.getdbt.com#830

Things are looking good as I manually merge the PRs. `dbt deps` keeps finding and successfully installing package after package, which is a great sign.

Since the major deployment, I found one little bug that was quickly fixed over in [hubcap](https://github.com/dbt-labs/hubcap/pull/63). 