### PR TITLE
fix empty package config causing error when running deps on 0.7.2

### DIFF
--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.2.json
@@ -3,7 +3,7 @@
     "name": "dbt_utils",
     "version": "0.7.2",
     "published_at": "2021-09-15T15:02:24.952883+00:00",
-    "packages": null,
+    "packages": [],
     "works_with": [],
     "_source": {
         "type": "github",


### PR DESCRIPTION
Saw an issue where packages config was getting set to null - this should be '[]' instead