### PR TITLE
Use middleman redirect to send package uris to preexisting latest version uris.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ bundle exec middleman serve --port 4567
 
 ### In directory bundling
 
-To keep your keeps in a repo vendor folder, use the `--install-dir` flag with the gem install commands above but do so _before_ the `--` (this is critical).
+To install gems to the project repo (as opposed to your system-user-level gem folder), use the `--install-dir` flag with the gem install commands above. However, place this flag and corresponding directory path argument _before_ the `--` (this is critical).

--- a/README.md
+++ b/README.md
@@ -19,10 +19,26 @@ git submodule update --init
 ```bash
 bundle install
 ```
-_If this fails, take a look at [this thread](https://gist.github.com/fernandoaleman/868b64cd60ab2d51ab24e7bf384da1ca#gistcomment-3082045)._
+_For mac users, if this fails for MacOS <0.16, take a look at [this thread](https://gist.github.com/fernandoaleman/868b64cd60ab2d51ab24e7bf384da1ca#gistcomment-3082045). For Big Sur users, try the following adapted from [this thread](https://github.com/shakacode/react-webpack-rails-tutorial/issues/266):_
+
+```
+env \                                                                                                                                                     master
+  CXX=clang++ \
+  GYPFLAGS=-Dmac_deployment_target=10.16 \  # substitute 10.16 for whatever your Mac OS version is
+gem install libv8 --version 3.16.14.19  # exact version may differ on your system
+
+gem install therubyracer -v ‘<whatever version bundler requests>’ -- --with-v8-dir=/usr/local/opt/v8@3.15
+```
+Note, the precise version of the `with-v8-dir` may differ from what is listed above. Do consult that directory for whatever version your homebrew installed.
+
+Now rerun `bundle install`
 
 ...and run with middleman:
 
 ```bash
 bundle exec middleman serve --port 4567
 ```
+
+### In directory bundling
+
+To keep your keeps in a repo vendor folder, use the `--install-dir` flag with the gem install commands above but do so _before_ the `--` (this is critical).

--- a/config.rb
+++ b/config.rb
@@ -85,6 +85,8 @@ after_configuration do
               :package => package
             }
 
+      redirect "#{package_name}/index.html", to: "/#{package_name}/latest/index.html"
+
       package.versions.each do |version, package_version|
         proxy "#{package_name}/#{version}/index.html",
               "/package.template.html",


### PR DESCRIPTION
# Purpose

1️⃣  Closes #118
1 line solution that comes from a few iterations of experimentation. This address the the problem idiomatically and in a well-defined way.

I heartily invite you to inspect the behavior for yourself on the Netlify deploy :)

2️⃣  Documentation additions
Added documentation for how I got local development working on Big Sur.

# Impact

Redirect to latest version of a package, with no duplicating of uri "space" (cf. search space). This solution in particular requires no intervention on the web server layer yet keeps uris sensible for SEO tracking and such.

## Dev notes

Here's a trivial solution: "Just" add this code in `config.rb` (the equivalent in Middleman apps to the more ubiquitous, Rails-style `routes.rb`):
```ruby
      proxy "/#{package_name}/",
            '/package.template.html',
            :content_type => 'text/html',
            :layout => 'layout',
            :locals => {
              :package => package,
              :version => package.versions[package.latest]
            }
```

##### Caveat: package_name is actually `<org-name>/<package-name>`. Don't be fooled like I was at first!

One problem--when you reflect on it, this isn't a true redirect to the `latest` uri of a package. Instead, this exact uri `/#{package_name}/` is being invented with directions to call the same function as other already established uris. This is artificial. Here's some evidence (for the worse): to have `/#{package_name}/` AND `/#{package_name}` work, you must repeat this code a _second_ time for none /-suffix `/#{package_name}/` uris`. Welcome to the same SEO metric split across 3 dimensions.

To get that 🔥 301-like action, Middleman provides a could-be-better-documented [`redirect`](https://middlemanapp.com/basics/redirects/) builtin. This intercepts the uri and reroutes to `/#{package_name}/latest` (no duplication, or in this case triplication, of url search space needed). Hence, the redirect solution, with some clever trial and error to discover the exact syntax needed to redirect

TL;DR Middleman wants files to be redirected files, so to define behavior on directory uris, use the `index.html` behavior of HTTPS.