### PR TITLE
Add workflow to automatically rebase PRs

### DIFF
--- a/.github/workflows/rebase-pull-requests.yml
+++ b/.github/workflows/rebase-pull-requests.yml
@@ -1,0 +1,9 @@
+name: Rebase Pull Requests
+on:
+  push:
+    branches: [master]
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: linhbn123/rebase-pull-requests@v1.0.1


### PR DESCRIPTION
As I understand it, there is an issue with the current Hubcap -> hub.getdbt.com workflow where if multiple releases are tracked at the same time, only one of the PRs that gets created can be auto-merged because the subsequent PRs no longer have a clean merge into `master`.

This change implements a new GitHub Actions workflow to rebase any open PR each time a commit to master happens. As a result, it should sequentially update each PR, which in turn will sequentially get merges into `master`. This means that multiple releases can all happen within the same hour and people won't have to push one release every hour. 