### PR TITLE
Reprioritize Featured Packages to include the `codegen` package

### DIFF
--- a/data/featured.json
+++ b/data/featured.json
@@ -9,6 +9,6 @@
     },
     {
         "org": "dbt-labs",
-        "package": "snowplow"
+        "package": "codegen"
     }
 ]


### PR DESCRIPTION
Closes #1455 

## Rationale
- elevates discoverability of the `codegen` package
    - we recommend that most teams should use the `codegen` package
- the community should use [official package(s) from Snowplow](https://hub.getdbt.com/snowplow/) instead of the [dbt Labs version](https://hub.getdbt.com/dbt-labs/snowplow/latest/) (which we should deprecate)
- maintains only 3 featured packages