### PR TITLE
Redirect to new name of package by elementary-data

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -3,6 +3,7 @@
         "fishtown-analytics"
     ],
     "packages": [
+        "elementary-data/elementary_data_reliability",
         "dbt-labs/bing-ads",
         "dbt-labs/bing_ads",
         "dbt-labs/dbt-event-logging",

--- a/data/packages/elementary-data/elementary_data_reliability/index.json
+++ b/data/packages/elementary-data/elementary_data_reliability/index.json
@@ -3,6 +3,7 @@
     "namespace": "elementary-data",
     "description": "dbt models for dbt-data-reliability",
     "latest": "0.1.1",
+    "redirectname": "elementary",
     "assets": {
         "logo": "logos/placeholder.svg"
     }


### PR DESCRIPTION
Closes #1460

## Solution
Combine the two package listings for elementary-data into one by following [this](https://github.com/dbt-labs/hub.getdbt.com/pull/876/files) example.

(If the namespace was being renamed, we'd use [this](https://github.com/dbt-labs/hub.getdbt.com/pull/1220/files)  example instead.)

## Design choices

Put the change to the top of the blocklist instead of the bottom (reverse chronological).

Rationale: JSON doesn't supply trailing commas for the last item in a list, so chronological additions end up with longer diffs.

So we get this diff:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/44704949/162252095-e7350ad2-b0cb-48d9-b9a0-cea7d614a12d.png">

Instead of one like this:
<img width="494" alt="image" src="https://user-images.githubusercontent.com/44704949/162252698-ff2f6492-1e5b-4bcb-8057-2ef7c57164e4.png">
