### PR TITLE
Fix capitilization for GitHub

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -83,7 +83,7 @@
                 </li>
 			    <li>
                   <a href="https://github.com/dbt-labs/dbt"
-                     target="_blank">Github</a>
+                     target="_blank">GitHub</a>
                 </li>
 		      </ul>
 		      <ul>

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -77,7 +77,7 @@ packages:
       <div class="row">
         <div class="col-md-12">
           <h3>README</h3>
-          (<a href="<%= version._source.url %>">View on Github</a>)
+          (<a href="<%= version._source.url %>">View on GitHub</a>)
         </div>
       </div>
       <hr>


### PR DESCRIPTION
Resolves #1718

Simple and easy fix 😄 

## Before

<img width="184" alt="image" src="https://user-images.githubusercontent.com/44704949/181537468-3add2365-59ec-40ef-9a77-53ada958343a.png">

<img width="368" alt="image" src="https://user-images.githubusercontent.com/44704949/181536808-592fa8c2-1e52-46a2-a3dd-5252d9441d3d.png">

## After

<img width="195" alt="image" src="https://user-images.githubusercontent.com/44704949/181547621-14a29b77-40b9-4912-9447-70a06c06aa19.png">

<img width="351" alt="image" src="https://user-images.githubusercontent.com/44704949/181547339-ecacc90e-92bc-44aa-9578-c3e0d5a4f408.png">
