### PR TITLE
Alphabetize packages on each org-specific page (same as the home page)

### DIFF
--- a/source/author.template.html.erb
+++ b/source/author.template.html.erb
@@ -28,7 +28,8 @@
     <div class="section-content">
       <div class="row">
         <div class="tiles">
-          <% config[:package_index].each do |name, package| %>
+          <% packages = config[:package_index].sort_by {|name, package| name.downcase} %>
+          <% packages.each do |name, package| %>
           <% if package.namespace == author %>
             <% if not data.blocklist['packages'].include?(package.namespace + "/" + package.name) %>
               <%= partial "package_card", :locals => { :package => package } %>


### PR DESCRIPTION
Resolves #1675

Here's how an alphabetized version looks:

<img width="356" alt="image" src="https://user-images.githubusercontent.com/44704949/181866095-e8106e16-1da1-4ede-99fd-58c0b49c7b45.png">
