### PR TITLE
Recreate `dbt_utils` specs with `require_dbt_version`

### DIFF
--- a/data/packages/dbt-labs/dbt_utils/versions/0.0.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.0.1.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.0.1",
     "name": "dbt_utils",
     "version": "0.0.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.0.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.0",
     "name": "dbt_utils",
     "version": "0.1.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.1.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.1",
     "name": "dbt_utils",
     "version": "0.1.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.10.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.10.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.10",
     "name": "dbt_utils",
     "version": "0.1.10",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.11.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.11.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.11",
     "name": "dbt_utils",
     "version": "0.1.11",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.12.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.12.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.12",
     "name": "dbt_utils",
     "version": "0.1.12",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.13.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.13.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.13",
     "name": "dbt_utils",
     "version": "0.1.13",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.14.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.14.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.14",
     "name": "dbt_utils",
     "version": "0.1.14",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.15.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.15.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.15",
     "name": "dbt_utils",
     "version": "0.1.15",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.16.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.16.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.16",
     "name": "dbt_utils",
     "version": "0.1.16",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.17.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.17.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.17",
     "name": "dbt_utils",
     "version": "0.1.17",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.18.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.18.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.18",
     "name": "dbt_utils",
     "version": "0.1.18",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.19.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.19.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.19",
     "name": "dbt_utils",
     "version": "0.1.19",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.2.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.2",
     "name": "dbt_utils",
     "version": "0.1.2",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.20.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.20.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.20",
     "name": "dbt_utils",
     "version": "0.1.20",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.21.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.21.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.21",
     "name": "dbt_utils",
     "version": "0.1.21",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.22.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.22.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.22",
     "name": "dbt_utils",
     "version": "0.1.22",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.23.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.23.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.23",
     "name": "dbt_utils",
     "version": "0.1.23",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.13.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.24.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.24.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.24",
     "name": "dbt_utils",
     "version": "0.1.24",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.13.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.25.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.25.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.25",
     "name": "dbt_utils",
     "version": "0.1.25",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.13.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.3.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.3",
     "name": "dbt_utils",
     "version": "0.1.3",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.4.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.4",
     "name": "dbt_utils",
     "version": "0.1.4",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.5.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.5",
     "name": "dbt_utils",
     "version": "0.1.5",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.6.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.6.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.6",
     "name": "dbt_utils",
     "version": "0.1.6",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.7.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.7.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.7",
     "name": "dbt_utils",
     "version": "0.1.7",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.8.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.8.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.8",
     "name": "dbt_utils",
     "version": "0.1.8",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.1.9.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.1.9.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.1.9",
     "name": "dbt_utils",
     "version": "0.1.9",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.0.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.0",
     "name": "dbt_utils",
     "version": "0.2.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.1.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.1",
     "name": "dbt_utils",
     "version": "0.2.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.2.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.2",
     "name": "dbt_utils",
     "version": "0.2.2",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.3.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.3",
     "name": "dbt_utils",
     "version": "0.2.3",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.4.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.4",
     "name": "dbt_utils",
     "version": "0.2.4",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.2.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.2.5.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.2.5",
     "name": "dbt_utils",
     "version": "0.2.5",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.14.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.3.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.3.0.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.3.0",
     "name": "dbt_utils",
     "version": "0.3.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.15.1",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.4.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.4.0.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.4.0",
     "name": "dbt_utils",
     "version": "0.4.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.17.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.4.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.4.1.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.4.1",
     "name": "dbt_utils",
     "version": "0.4.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.17.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.5.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.5.0.json
@@ -2,8 +2,9 @@
     "id": "dbt-labs/dbt_utils/0.5.0",
     "name": "dbt_utils",
     "version": "0.5.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": ">=0.17.0",
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.5.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.5.1.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.5.1",
     "name": "dbt_utils",
     "version": "0.5.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.17.0",
+        "<0.18.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.0.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.0",
     "name": "dbt_utils",
     "version": "0.6.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.19.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.1.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.1",
     "name": "dbt_utils",
     "version": "0.6.1",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.19.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.2.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.2",
     "name": "dbt_utils",
     "version": "0.6.2",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.19.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.3.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.3",
     "name": "dbt_utils",
     "version": "0.6.3",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.20.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.4.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.4",
     "name": "dbt_utils",
     "version": "0.6.4",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.20.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.5.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.5",
     "name": "dbt_utils",
     "version": "0.6.5",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.20.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.6.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.6.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.6.6",
     "name": "dbt_utils",
     "version": "0.6.6",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.18.0",
+        "<0.20.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.0.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.0",
     "name": "dbt_utils",
     "version": "0.7.0",
-    "published_at": "2021-07-01T22:01:31.990221+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<0.21.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.1.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.1",
     "name": "dbt_utils",
     "version": "0.7.1",
-    "published_at": "2021-08-06T13:02:46.961504+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<0.22.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.2.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.2",
     "name": "dbt_utils",
     "version": "0.7.2",
-    "published_at": "2021-09-15T15:02:24.952883+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<0.22.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.3.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.3",
     "name": "dbt_utils",
     "version": "0.7.3",
-    "published_at": "2021-09-17T19:34:27.187538+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<0.22.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.4-b1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.4-b1.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.4-b1",
     "name": "dbt_utils",
     "version": "0.7.4-b1",
-    "published_at": "2021-11-08T04:02:19.309014+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<=1.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.4.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.4",
     "name": "dbt_utils",
     "version": "0.7.4",
-    "published_at": "2021-11-11T04:02:12.383198+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<=1.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.5.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.5",
     "name": "dbt_utils",
     "version": "0.7.5",
-    "published_at": "2021-12-02T03:03:04.198523+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<=1.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.7.6.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.7.6.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.7.6",
     "name": "dbt_utils",
     "version": "0.7.6",
-    "published_at": "2021-12-02T22:02:08.207858+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=0.20.0",
+        "<1.1.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.0.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.0",
     "name": "dbt_utils",
     "version": "0.8.0",
-    "published_at": "2021-12-02T22:02:08.207858+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.1.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.1",
     "name": "dbt_utils",
     "version": "0.8.1",
-    "published_at": "2022-02-23T03:00:44.120148+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.2.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.2",
     "name": "dbt_utils",
     "version": "0.8.2",
-    "published_at": "2022-03-03T03:00:59.530779+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.3.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.3",
     "name": "dbt_utils",
     "version": "0.8.3",
-    "published_at": "2022-04-07T23:00:57.443691+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.4.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.4",
     "name": "dbt_utils",
     "version": "0.8.4",
-    "published_at": "2022-04-08T03:01:38.932309+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.5.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.5",
     "name": "dbt_utils",
     "version": "0.8.5",
-    "published_at": "2022-05-17T18:00:55.001905+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",

--- a/data/packages/dbt-labs/dbt_utils/versions/0.8.6.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.8.6.json
@@ -2,8 +2,12 @@
     "id": "dbt-labs/dbt_utils/0.8.6",
     "name": "dbt_utils",
     "version": "0.8.6",
-    "published_at": "2022-06-15T20:00:28.502048+00:00",
+    "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
+    "require_dbt_version": [
+        ">=1.0.0",
+        "<2.0.0"
+    ],
     "works_with": [],
     "_source": {
         "type": "github",


### PR DESCRIPTION
Created programmatically using: https://github.com/dbt-labs/hubcap/pull/146

In order to test: https://github.com/dbt-labs/dbt-core/pull/5651

```yml
# packages.yml
packages:
  - package: dbt-labs/dbt_utils
    version: 0.6.5
```
```
$ export DBT_PACKAGE_HUB_URL="https://deploy-preview-1770--flamboyant-mcclintock-92ba2d.netlify.app/"
$ dbt deps
15:57:07  Running with dbt=1.3.0-b1
15:57:09  Encountered an error:
Could not find a matching compatible version for package dbt-labs/dbt_utils
  Requested range: =0.6.5, =0.6.5
  Compatible versions: ['0.0.1', '0.1.0', '0.1.1', '0.1.2', '0.1.3', '0.1.4', '0.1.5', '0.1.6', '0.1.7', '0.1.8', '0.1.9', '0.1.10', '0.1.11', '0.1.12', '0.1.13', '0.1.14', '0.1.15', '0.1.16', '0.1.17', '0.1.18', '0.1.19', '0.1.20', '0.1.21', '0.1.22', '0.1.23', '0.1.24', '0.1.25', '0.2.0', '0.2.1', '0.2.2', '0.2.3', '0.2.4', '0.2.5', '0.3.0', '0.4.0', '0.4.1', '0.5.0', '0.8.0', '0.8.1', '0.8.2', '0.8.3', '0.8.4', '0.8.5', '0.8.6']
  (Not shown: versions incompatible with installed version of dbt-core)
```

(All those very old versions of `dbt-utils` are considered "compatible" because they do not define `require-dbt-version`.)