### PR TITLE
Fix the display of summary blocks

### DIFF
--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -21,3 +21,12 @@ pre {
     background-color: #f6f8fa;
     color: #24292e;
 }
+
+
+// https://css-tricks.com/careful-when-changing-the-display-of-summary/
+summary {
+    // to make summaries show with the triangle
+    display: list-item;
+    // to render the summaries a bit better when they are one after the other
+    margin-top: 16px
+}


### PR DESCRIPTION
Related to #1583

Update to fix how summary blocks are displayed. The issue was that a stylesheet from the old `www.getdbt.com` was overriding `summary.display` to `block`.

The following screenshots are from https://hub.getdbt.com/dbt-labs/dbt_project_evaluator/0.1.0/ , next to "Using This Package".

This is still not 100% perfect, especially when special formatting is done within the `details` tag, but based on my troubleshooting, this is a limitation of [kramdown](https://github.com/gettalong/kramdown), the MD renderer used in `middleman`. ([Here is a demo](https://kramdown-sandbox.herokuapp.com/) of kramdown if someone wants to try specific behavior). But I feel that this is still a pretty big improvement compare to the current behavior.

## How it shows in GitHub:
### Collapsed
![image](https://user-images.githubusercontent.com/8754100/185493111-1f15c6fd-b093-4aa6-a984-c6cd31564c49.png)
### Opened
![image](https://user-images.githubusercontent.com/8754100/185493163-6269a894-d86f-4843-9e05-265b37a9d9d7.png)

## How it shows in the current Hub:
### Collapsed
![image](https://user-images.githubusercontent.com/8754100/185492518-02f95a75-9f51-444c-8ac3-99dc94b948fa.png)
### Opened
![image](https://user-images.githubusercontent.com/8754100/185492564-fb83063d-66cc-4e6e-94db-a0e4154998ed.png)

## How it shows on the Hub after this change:
### Collapsed
![image](https://user-images.githubusercontent.com/8754100/185492609-73765a65-07fd-45ec-89f7-268452536201.png)
### Opened
![image](https://user-images.githubusercontent.com/8754100/185492647-8177eb26-71a2-4d00-84d8-b025e7b135b0.png)
