### PR TITLE
Use updated version of marked.js

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -22,7 +22,7 @@
     <%= stylesheet_link_tag 'hljs/styles/github' %>
     <%= javascript_include_tag 'hljs/highlight.pack' %>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.6/marked.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.18/marked.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -97,7 +97,7 @@ packages:
 
 <script>
   $.get('<%= version._source.readme %>').done(function(data) {
-      document.getElementById('readme').innerHTML = marked(data)
+      document.getElementById('readme').innerHTML = marked.parse(data)
 
   });
   $('#install').each(function(i, block) {


### PR DESCRIPTION
Clearly nerd-sniped on this one 😄  but I wasn't happy enough with the poor rendering in the `details` block after my previous fix.

After further investigation, I realized that the rendering of MD is not done by `middleman` itself but by `marked.js` as a JS script. After updating `marked.js` to a much more recent version the rendering looks much better!

### Screenshot of the `details` section after this change:
![image](https://user-images.githubusercontent.com/8754100/185591620-583ee257-d907-4625-92d3-5b8cfcacf9c1.png)

It now looks identical to GitHub!

This will be very helpful for dbt_project_evaluator as we can now use and abuse `summary`/`details` and still get it rendering well on the Hub.