### PR TITLE
Put Github badges on one row

### DIFF
--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -34,3 +34,7 @@ summary {
 img {
     display: inline;
 }
+
+.hub-logo > img {
+    display: block;
+}

--- a/source/stylesheets/main.css.scss
+++ b/source/stylesheets/main.css.scss
@@ -30,3 +30,7 @@ summary {
     // to render the summaries a bit better when they are one after the other
     margin-top: 16px
 }
+
+img {
+    display: inline;
+}


### PR DESCRIPTION
Last update from my side related to #1583

This change puts the different badges on a single row instead of one below each other. 
They are still not centered but fixing the alignment will require much more work as the style is defined as "inherited" in the old css files.

## Updated screenshot for the Fivetran Logs package
![image](https://user-images.githubusercontent.com/8754100/185964035-2ed8f03e-0791-4bd2-951e-7a382c4c6b73.png)
