### PR TITLE
Remove git submodules from installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,21 +23,9 @@ There are two components to the [dbt Hub](https://hub.getdbt.com/):
 
 See the [installing Ruby for Mac](#installing-ruby-for-mac) and [troubleshooting](#troubleshooting) sections below as-needed.
 
-Clone this repository and install submodules:
-
-```
-git submodule update --init
-```
-
-...then install dependencies with `bundler`:
-
+Install dependencies with `bundler` and run with middleman:
 ```bash
 bundle install
-```
-
-...and run with middleman:
-
-```bash
 bundle exec middleman serve --port 4567
 ```
 


### PR DESCRIPTION
Continues #1788 (bulk of the work in #1782).

Assuming the necessary Ruby environment is all set up, the install+run instructions are now as simple as:

> Install dependencies with `bundler` and run with middleman:
> ```bash
> bundle install
> bundle exec middleman serve --port 4567
> ```