### PR TITLE
Show dbt version required

### DIFF
--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -60,7 +60,22 @@
 
       <div class="row">
         <div class="col-md-12">
-          <h3>Installation</h3>
+
+        <h3>Installation</h3>
+        
+        dbt version required: <%=
+        if version.require_dbt_version != nil && version.require_dbt_version.length() > 0
+          then 
+            if version.require_dbt_version.kind_of?(Array)
+              "<code>" + version.require_dbt_version.join(', ') + "</code>"
+            else
+              "<code>" + version.require_dbt_version + "</code>"
+            end
+          else
+            "Not defined" 
+          end
+      %>
+
           <p>Include the following in your <code>packages.yml</code> file:
           <pre id='install'>
 packages:


### PR DESCRIPTION
Fixes #165

The new logic shows the dbt version required. I tested it with:
- removing `require_dbt_version` for a package JSON (in case it's not getting populated for some reason)
- `require_dbt_version` being an empty array (defined but empty)
- `require_dbt_version` being an array (most of the cases, with a lower and upper bound)
- `require_dbt_version` being a string

Keen for any feedback on how we should show it.

### Empty array
![image](https://user-images.githubusercontent.com/8754100/186629798-f3e3ffca-79f3-467f-a63d-36840f0a0842.png)

### Filled array
![image](https://user-images.githubusercontent.com/8754100/186629938-1618055b-353a-490e-a3eb-ee98632d99f4.png)

### String
![image](https://user-images.githubusercontent.com/8754100/186630040-3dd9c758-976d-425a-b6de-e49beff364ed.png)
