### PR TITLE
Fix sorting semver

### DIFF
--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -57,7 +57,7 @@
                       style="min-width: 225px"
                       id="version"
                       onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
-                <% for local_version, package_version in package.versions.sort_by { |v| Gem::Version.new(v[0]) }.reverse %>
+                <% for local_version, _package_version in package.versions.sort_by { |key, _val| Gem::Version.new(key) }.reverse %>
                 <option value="<%= site_url %>/<%= package.namespace %>/<%= package.name %>/<%= local_version %>"
                         <% if local_version == version.version %>selected="selected"<% end %>>
                   <%= local_version %><% if local_version == package.latest %> (latest)<% end %>

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -57,7 +57,7 @@
                       style="min-width: 225px"
                       id="version"
                       onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
-                <% for local_version, package_version in package.versions.sort.reverse %>
+                <% for local_version, package_version in package.versions.sort_by { |v| Gem::Version.new(v[0]) }.reverse %>
                 <option value="<%= site_url %>/<%= package.namespace %>/<%= package.name %>/<%= local_version %>"
                         <% if local_version == version.version %>selected="selected"<% end %>>
                   <%= local_version %><% if local_version == package.latest %> (latest)<% end %>


### PR DESCRIPTION
Fixes #1458 

Leverages the snippets from [this SO page](https://stackoverflow.com/questions/33289799/version-sort-with-alphas-betas-etc-in-ruby)

### Example with `dbt_utils`
![image](https://user-images.githubusercontent.com/8754100/186638628-91f5f4fa-8972-4e2c-9471-9f8ada6438bb.png)
