### PR TITLE
Show package link to Github and number of stars in nav bar

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -141,6 +141,10 @@ helpers do
   def is_latest(package, version)
     package.latest == version['version']
   end  
+
+  def is_valid_github_url(url)
+    url.split("/tree/").length == 2 && url.split("/").length >= 5
+  end  
 end
 
 ignore '/package.template.html.erb'

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -8,19 +8,6 @@
             		<img src='<%= site_url %>/img/logos/dbt-lockup.png' style="height: 48px"/>
 		  </a>
 		</div>
-		<% if defined?(version) && is_valid_github_url(version._source.url) %>
-		<div class="navigation-link">
-		     <a class="btn btn-teal btn-shadow github-button" style="background-color:#047377;color:#fff"
-			href="<%=version._source.url.split("/tree/")[0]%>"
-			data-size="large"
-			data-show-count="true"
-			aria-label="Star the package on GitHub"
-			target="_blank">
-			     <i data-icon="star"></i>
-			     <%= version._source.url.split("/")[3] %>/<%= version._source.url.split("/")[4] %>
-			</a>
-		</div>
-		<% end %>
 		<div class="navigation-link">
 		     <a class="btn btn-teal btn-shadow" style="background-color:#047377;color:#fff"
 			href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -8,17 +8,19 @@
             		<img src='<%= site_url %>/img/logos/dbt-lockup.png' style="height: 48px"/>
 		  </a>
 		</div>
+		<% if defined?(version) %>
 		<div class="navigation-link">
 		     <a class="btn btn-teal btn-shadow github-button" style="background-color:#047377;color:#fff"
-			href="https://github.com/dbt-labs/dbt"
+			href="<%=version._source.url.split("/tree")[0]%>"
 			data-size="large"
 			data-show-count="true"
-			aria-label="Star dbt-labs/dbt on GitHub"
+			aria-label="Star the package on GitHub"
 			target="_blank">
 			     <i data-icon="star"></i>
-			     GitHub
+			     <%= version._source.url.split("/")[3] %>/<%= version._source.url.split("/")[4] %>
 			</a>
 		</div>
+		<% end %>
 		<div class="navigation-link">
 		     <a class="btn btn-teal btn-shadow" style="background-color:#047377;color:#fff"
 			href="https://docs.getdbt.com/docs/building-a-dbt-project/package-management"

--- a/source/_nav.erb
+++ b/source/_nav.erb
@@ -8,10 +8,10 @@
             		<img src='<%= site_url %>/img/logos/dbt-lockup.png' style="height: 48px"/>
 		  </a>
 		</div>
-		<% if defined?(version) %>
+		<% if defined?(version) && is_valid_github_url(version._source.url) %>
 		<div class="navigation-link">
 		     <a class="btn btn-teal btn-shadow github-button" style="background-color:#047377;color:#fff"
-			href="<%=version._source.url.split("/tree")[0]%>"
+			href="<%=version._source.url.split("/tree/")[0]%>"
 			data-size="large"
 			data-show-count="true"
 			aria-label="Star the package on GitHub"

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -32,6 +32,19 @@
                   <%= package.namespace %>
                 </a>
               </em><br/>
+              <% if is_valid_github_url(version._source.url) %>
+              <div class="github-link" style="height: 30px;margin-bottom: 0" >
+               <a class="github-button"
+                href="<%=version._source.url.split("/tree/")[0]%>"
+                data-size="large"
+                data-show-count="true"
+                aria-label="Star the package on GitHub"
+                target="_blank">
+                     <i data-icon="star"></i>
+                     <%= version._source.url.split("/")[3] %>/<%= version._source.url.split("/")[4] %>
+                </a>
+              </div>
+              <% end %>
               <em><%= package.versions[package.latest].description %></em>
             </div>
           </div>


### PR DESCRIPTION
POC related to #1724 but with a different approach. Feel free to just close it if we don't want to implement it.

The link to dbt-core's repo in GitHub is removed from the main page but it is replaced by links to individual packages, showing the number of stars for each package.

In that case, the key difference between the link in the nav bar and the link in the body is that the nav bar points to the main/master branch when the body points to the actual branch the user has selected.

### Main page
![image](https://user-images.githubusercontent.com/8754100/186649294-be07dc60-c3a5-446e-8bb9-d373799fe5b6.png)

### Package page
![image](https://user-images.githubusercontent.com/8754100/186649431-7cb3ac8d-499f-41e6-8297-0241c7f58d7f.png)

 