### PR TITLE
Archive tuva-health medicare connector package(s)

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -8,6 +8,8 @@
         "tailsdotcom/dbt_artifacts",
         "cerebriumai/github",
         "tuva-health/tuva",
+        "tuva-health/medicare_cclf_connector",
+        "tuva-health/medicare_claims_connector",
         "elementary-data/elementary_data_reliability",
         "dbt-labs/bing-ads",
         "dbt-labs/bing_ads",


### PR DESCRIPTION
Per discussion in https://github.com/dbt-labs/hubcap/pull/203

There were two scopes of work discussed:
1. Renaming the "core" package to "the_tuva_project" within the Hub
1. Archiving the "medicare_cclf_connector" and "medicare_claims_connector" packages

This PR covers the only latter (and not the former).