### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Auto-label
-        uses: actions/labeler@v2
+        uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Auto-merge
-        uses: pascalgn/automerge-action@v0.14.2
+        uses: pascalgn/automerge-action@v0.15.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: "automerge,!work in progress,!ready for review"

--- a/.github/workflows/rebase-pull-requests.yml
+++ b/.github/workflows/rebase-pull-requests.yml
@@ -6,4 +6,4 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: linhbn123/rebase-pull-requests@v1
+      - uses: linhbn123/rebase-pull-requests@v1.0.1

--- a/.github/workflows/rebase-pull-requests.yml
+++ b/.github/workflows/rebase-pull-requests.yml
@@ -6,4 +6,4 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: linhbn123/rebase-pull-requests@v1.0.1
+      - uses: linhbn123/rebase-pull-requests@v1


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144