### PR TITLE
Update preview url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ export DBT_PACKAGE_HUB_URL=http://localhost:4567/
 
 Or if you have a Netlify preview created by a pull request:
 ```
-export DBT_PACKAGE_HUB_URL=https://deploy-preview-1717--flamboyant-mcclintock-92ba2d.netlify.app/
+export DBT_PACKAGE_HUB_URL=https://deploy-preview-1717--hub-getdbt-com.netlify.app/
 ```
 
 Suppose your `packages.yml` in your dbt project contains the following content:


### PR DESCRIPTION
This updates the preview URL to the correct Netlify site name within the `CONTRIBUTING.md` file.

Note - This will need to be updated again once Hub is migrated to Vercel.