### PR TITLE
Increase sleep and retries for auto merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,14 +11,16 @@ permissions: write-all
 
 
 jobs:
-  automerge:
+  autolabel:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label
         uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.AUTOMERGE_PAT }}
-
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
       - name: Auto-merge
         uses: pascalgn/automerge-action@v0.15.6
         env:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,3 +26,5 @@ jobs:
           MERGE_LABELS: "automerge,!work in progress,!ready for review"
           MERGE_REMOVE_LABELS: "automerge"
           LOG: DEBUG
+          MERGE_RETRIES: 10
+          MERGE_RETRY_SLEEP: 60000

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           repo-token: ${{ secrets.AUTOMERGE_PAT }}
   automerge:
+    needs: autolabel
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge
         uses: pascalgn/automerge-action@v0.15.6
-        needs: autolabel
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
           MERGE_LABELS: "automerge,!work in progress,!ready for review"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Auto-merge
         uses: pascalgn/automerge-action@v0.15.6
+        needs: autolabel
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
           MERGE_LABELS: "automerge,!work in progress,!ready for review"


### PR DESCRIPTION
Although the automerge GHA is configured to not fire until the Vercel build has succeeded (as a required check), it seems to be triggering after the build _begins_ but before the result is reported. 

In lieu of working out _why_, this increases the retry time and count. It takes about 5mins, so 10 attempts with a 1min standdown in between will be plenty. 

We should obviously work out the actual underlying problem, but not right before I go on leave.