### PR TITLE
Update blocklist.json

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -55,6 +55,7 @@
         "Saras-Daton/shopify",
         "Saras-Daton/amazon_ads",
         "Saras-Daton/amazon_sellerpartner",
-        "Saras-Daton/amazon_vendorcentral" 
+        "Saras-Daton/amazon_vendorcentral",
+        "TasmanAnalytics/tasman_dbt_package"
     ]
 }


### PR DESCRIPTION
A small tweak to add the old package name to the blocklist, so that it is not longer on the dbt package hub twice. 