### PR TITLE
Suppress codeowner notifications for package bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,6 @@
 
 deploy.sh   @cmcarthur
 .github     @cmcarthur
+
+#Content in this directory 
+data/packages/ #these JSON files are auto-generated code and don't need review


### PR DESCRIPTION
## Motivation
[Hubcap](https://github.com/dbt-labs/hubcap) identifies new package releases and opens a PR against this repo, which is automatically merged. Because the DX team has responsibility for the repo per the new codeowners file, we are now getting notified on every new package release. We don't need to know! 

## Fix
Specify the codegenned directories under data/packages/ as having no owner, so that DX doesn't get emailed about things like #3653. (Per https://stackoverflow.com/a/74964396/14007029)

## Alternative option, I guess
Each DX employee sets up gmail rules to auto-archive the unwanted emails