### PR TITLE
Redirect dbt-date from Calogica to GoDataDriven

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -58,6 +58,6 @@
         "Saras-Daton/amazon_sellerpartner",
         "Saras-Daton/amazon_vendorcentral",
         "TasmanAnalytics/tasman_dbt_package",
-        "calogica/dbt-date"
+        "calogica/dbt_date"
     ]
 }

--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -57,6 +57,7 @@
         "Saras-Daton/amazon_ads",
         "Saras-Daton/amazon_sellerpartner",
         "Saras-Daton/amazon_vendorcentral",
-        "TasmanAnalytics/tasman_dbt_package"
+        "TasmanAnalytics/tasman_dbt_package",
+        "calogica/dbt-date"
     ]
 }

--- a/data/packages/calogica/dbt_date/index.json
+++ b/data/packages/calogica/dbt_date/index.json
@@ -3,7 +3,7 @@
     "namespace": "calogica",
     "description": "dbt models for dbt-date",
     "latest": "0.10.1",
-    "redirectname": "godatadriven_dbt_date",
+    "redirectname": "godatadriven/dbt_date",
     "assets": {
         "logo": "logos/placeholder.svg"
     }

--- a/data/packages/calogica/dbt_date/index.json
+++ b/data/packages/calogica/dbt_date/index.json
@@ -3,7 +3,8 @@
     "namespace": "calogica",
     "description": "dbt models for dbt-date",
     "latest": "0.10.1",
-    "redirectname": "godatadriven/dbt_date",
+    "redirectname": "dbt_date",
+    "redirectnamespace": "godatadriven",
     "assets": {
         "logo": "logos/placeholder.svg"
     }

--- a/data/packages/calogica/dbt_date/index.json
+++ b/data/packages/calogica/dbt_date/index.json
@@ -3,6 +3,7 @@
     "namespace": "calogica",
     "description": "dbt models for dbt-date",
     "latest": "0.10.1",
+    "redirectname": "godatadriven_dbt_date",
     "assets": {
         "logo": "logos/placeholder.svg"
     }


### PR DESCRIPTION
Calogica's [dbt-date](https://github.com/calogica/dbt-date) package is no longer supported. This PR redirects to GoDataDriven's [dbt-date](https://github.com/godatadriven/dbt-date) package which is supported.