### PR TITLE
Redirect dbt-expectations from Calogica to Metaplane

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -4,6 +4,7 @@
         "fishtown-analytics"
     ],
     "packages": [
+        "calogica/dbt_expectations",
         "Datavault-UK/dbtvault",
         "rudderlabs/rudder_id_resolution",
         "tailsdotcom/dbt_artifacts",

--- a/data/featured.json
+++ b/data/featured.json
@@ -20,7 +20,7 @@
         "package": "dbt_external_tables"
     },
     {
-        "org": "calogica",
+        "org": "godatadriven",
         "package": "dbt_expectations"
     }
 ]

--- a/data/featured.json
+++ b/data/featured.json
@@ -20,7 +20,7 @@
         "package": "dbt_external_tables"
     },
     {
-        "org": "godatadriven",
+        "org": "metaplane",
         "package": "dbt_expectations"
     }
 ]

--- a/data/packages/calogica/dbt_expectations/index.json
+++ b/data/packages/calogica/dbt_expectations/index.json
@@ -3,6 +3,8 @@
     "namespace": "calogica",
     "description": "dbt models for dbt-expectations",
     "latest": "0.10.4",
+    "redirectname": "dbt_expectations",
+    "redirectnamespace": "godatadriven",
     "assets": {
         "logo": "logos/placeholder.svg"
     }

--- a/data/packages/calogica/dbt_expectations/index.json
+++ b/data/packages/calogica/dbt_expectations/index.json
@@ -4,7 +4,7 @@
     "description": "dbt models for dbt-expectations",
     "latest": "0.10.4",
     "redirectname": "dbt_expectations",
-    "redirectnamespace": "godatadriven",
+    "redirectnamespace": "metaplane",
     "assets": {
         "logo": "logos/placeholder.svg"
     }


### PR DESCRIPTION
Calogica's [dbt-expectations](https://github.com/calogica/dbt-expectations) package is no longer supported. This PR redirects to Metaplane's [dbt-expectations](https://github.com/metaplane/dbt-expectations) package which is supported.

## See also
https://github.com/dbt-labs/hub.getdbt.com/pull/3662