### PR TITLE
Re-tagged package not picked up (brooklyn-data/dbt_artifacts)

### DIFF
--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.9.3.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.9.3.json
@@ -6,7 +6,7 @@
     "packages": [],
     "require_dbt_version": [
         ">=1.3.0",
-        "<1.10.0"
+        "<1.11.0"
     ],
     "works_with": [],
     "_source": {


### PR DESCRIPTION
Updating this to match the actual package which is as follows:

```
name: "dbt_artifacts"
version: "2.9.3"
config-version: 2
require-dbt-version: [">=1.3.0", "<1.11.0"]
profile: "dbt_artifacts"
```

Link: https://github.com/brooklyn-data/dbt_artifacts/blob/main/dbt_project.yml