### PR TITLE
Update dbt_date v0.16.0's minimum dbt version

### DIFF
--- a/data/packages/godatadriven/dbt_date/versions/0.16.0.json
+++ b/data/packages/godatadriven/dbt_date/versions/0.16.0.json
@@ -5,7 +5,7 @@
     "published_at": "1970-01-01T00:00:00.000000+00:00",
     "packages": [],
     "require_dbt_version": [
-        ">=1.6.0",
+        ">=1.10.5",
         "<2.0.0"
     ],
     "works_with": [],


### PR DESCRIPTION
https://github.com/godatadriven/dbt-date/pull/25 added an inaccurate require-dbt-version config which was released in v0.16.0. https://github.com/godatadriven/dbt-date/pull/27 fixed that and was released in v0.16.1, but 0.16.0 still exists on the package hub. 

This PR forces the require-dbt-version on hub.getdbt.com to be correct. This means that the package won't be considered for dependency resolution (but it might require a cache invalidation on the S3 side as well - we'll have to check post-merge). 

Options for next steps: 
- Leave the package unchanged and rely on this manual change to exclude it from version resolution. This should be fine unless we ever rebuild the data directory from scratch one day (unlikely). This is my recommendation. 
- Delete this `data/packages/godatadriven/dbt_date/versions/0.16.0.json` file altogether, yanking the version from the hub. (🚨 this would require also removing the release and its corresponding tag in the https://github.com/godatadriven/dbt-date repo, otherwise it will be automatically re-added). This will be a problem if anyone has specified exactly 0.16.0 in their dbt_packages.yml file, because the package will no longer be findable. Slightly likely, 0.16.0 was the latest version for ~3 days so someone might have hardcoded it in that time. It's reasonably simple to recover from though, so this is my fallback recommendation. 
- Delete the release and its tag in the dbt-date repo, then create a new release called 0.16.0 with the correct version specification, then delete this `data/packages/godatadriven/dbt_date/versions/0.16.0.json` file and let it be recreated by hubcap at the top of the next hour. Bad idea because once a version is created it [must not be replaced](https://semver.org/#spec-item-3)