### PR TITLE
Add Fusion compatible downloads for dbt-project-evaluator

### DIFF
--- a/data/packages/dbt-labs/dbt_project_evaluator/versions/v1.1.0.json
+++ b/data/packages/dbt-labs/dbt_project_evaluator/versions/v1.1.0.json
@@ -56,6 +56,10 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-project-evaluator/tar.gz/v1.1.2",
+            "format": "tgz",
+            "sha1": "e004f2a8c9832633e0c100e31e878a4df5f1a86b"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_project_evaluator/versions/v1.1.1.json
+++ b/data/packages/dbt-labs/dbt_project_evaluator/versions/v1.1.1.json
@@ -56,6 +56,10 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-project-evaluator/tar.gz/v1.1.2",
+            "format": "tgz",
+            "sha1": "e004f2a8c9832633e0c100e31e878a4df5f1a86b"
+        }
     }
 }


### PR DESCRIPTION
dbt-project-evaluator versions 1.1.0 and 1.1.1 contained bugs that were fixed in 1.1.2 without introducing any additional changes, so projects that opt into Fusion compatible downloads can directly substitute these versions with 1.1.2.