### PR TITLE
Add dbt-kusuka package (convergence testing)

### DIFF
--- a/data/packages/achillesheel02/dbt-kusuka/index.json
+++ b/data/packages/achillesheel02/dbt-kusuka/index.json
@@ -1,0 +1,9 @@
+{
+    "name": "dbt-kusuka",
+    "namespace": "achillesheel02",
+    "description": "Dual-path convergence testing for dbt. Compare any two data paths and know exactly where they disagree, how much, and what kind of fix is needed.",
+    "latest": "0.1.0",
+    "assets": {
+        "logo": "logos/placeholder.svg"
+    }
+}

--- a/data/packages/achillesheel02/dbt-kusuka/versions/0.1.0.json
+++ b/data/packages/achillesheel02/dbt-kusuka/versions/0.1.0.json
@@ -1,0 +1,22 @@
+{
+    "id": "achillesheel02/dbt-kusuka/0.1.0",
+    "name": "dbt-kusuka",
+    "version": "0.1.0",
+    "published_at": "2026-04-14T00:00:00.000000+00:00",
+    "packages": [],
+    "require_dbt_version": [
+        ">=1.2.0",
+        "<3.0.0"
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/achillesheel02/dbt-kusuka/tree/v0.1.0/",
+        "readme": "https://raw.githubusercontent.com/achillesheel02/dbt-kusuka/v0.1.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/achillesheel02/dbt-kusuka/tar.gz/v0.1.0",
+        "format": "tgz",
+        "sha1": "056f2332d8f3e904aea7f3febddb13f8ef3f40a1"
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **dbt-kusuka** (`achillesheel02/dbt-kusuka`) v0.1.0 to the dbt Hub
- Dual-path convergence testing for dbt — compare any two data paths (models, queries, pipeline stages) and know exactly **where** they disagree, **how much**, and **what kind** of fix is needed
- Not anomaly detection. Convergence testing.

## Package details

| Field | Value |
|-------|-------|
| **Namespace** | `achillesheel02` |
| **Package** | `dbt-kusuka` |
| **Version** | `0.1.0` |
| **License** | Apache 2.0 |
| **Source** | https://github.com/achillesheel02/dbt-kusuka |
| **Docs** | https://thexi.dev/kusuka |

## What it does

8 macros and 4 generic tests for structured data comparison:

- `strand_verify` — compare two relations column-by-column (SMAPE + glyph matrix)
- `strand_verify_query` — compare two raw SQL queries without materializing models
- `strand_temporal` — convergence across time periods with dXi/dt drift detection
- `strand_report` / `strand_summary` — filtered gap reports and Frobenius norm rollups
- Generic tests: `kusuka_converge`, `kusuka_no_diverged`, `kusuka_no_nulls`, `kusuka_no_drift`

## Warehouse support

PostgreSQL, ClickHouse, BigQuery, Snowflake, DuckDB, Redshift.

## Checklist

- [x] `index.json` created with package metadata
- [x] `versions/0.1.0.json` created with sha1 from GitHub tarball
- [x] `require_dbt_version: >=1.2.0, <3.0.0`
- [x] No dependencies on other Hub packages
- [x] README at source repo documents all macros and tests