### PR TITLE
Migrate dbt-core test build from main to 1.latest

### DIFF
--- a/tests/core/Dockerfile
+++ b/tests/core/Dockerfile
@@ -47,7 +47,7 @@ RUN python -m pip install --upgrade "pip==24.0" "setuptools==69.2.0" "wheel==0.4
 
 FROM base AS dbt-core
 
-ARG commit_ref=main
+ARG commit_ref=1.latest
 
 HEALTHCHECK CMD dbt --version || exit 1
 
@@ -59,7 +59,7 @@ RUN python -m pip install --no-cache-dir "dbt-core @ git+https://github.com/dbt-
 
 FROM base AS dbt-postgres
 
-ARG commit_ref=main
+ARG commit_ref=1.latest
 
 HEALTHCHECK CMD dbt --version || exit 1
 


### PR DESCRIPTION
## Summary
- Update `commit_ref` default in [tests/core/Dockerfile](tests/core/Dockerfile) from `main` to `1.latest` for both the `dbt-core` and `dbt-postgres` build stages
- The dbt-core repo's `main` branch is being retired in favor of versioned release branches; `1.latest` tracks the latest supported 1.x release line

## Scope
Only [tests/core/Dockerfile](tests/core/Dockerfile) pulls dbt-core by git ref. Other `dbt-core` mentions in the repo ([docker-compose.yml](docker-compose.yml), [.github/workflows/test-deps.yml](.github/workflows/test-deps.yml), [CONTRIBUTING.md](CONTRIBUTING.md)) refer to the docker-compose service name and don't need changes.

## Test plan
- [ ] Manually trigger the `Test dbt deps` workflow (`.github/workflows/test-deps.yml`) and confirm the `dbt-core deps` step succeeds against the new branch
- [ ] Locally: `docker compose run dbt-core deps` builds and runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)