### PR TITLE
Change Elementary 0.24.0 to manually Fusion-compatible

### DIFF
--- a/data/packages/elementary-data/elementary/versions/0.24.0.json
+++ b/data/packages/elementary-data/elementary/versions/0.24.0.json
@@ -47,7 +47,7 @@
             "warnings": [],
             "fusion_version": "2.0.0-preview.178"
         },
-        "manually_verified_compatible": false,
+        "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
         "fusion_compatible_download": {}


### PR DESCRIPTION
The automated parse test fails with error 1005 ("The 'postgres' adapter is not yet supported by dbt Fusion") because the test harness defaults to the postgres adapter when no profiles.yml is present in the package. The elementary package is adapter-agnostic and has passing integration tests on all four Fusion-supported adapters (Snowflake, BigQuery, Databricks, Redshift).

Previous versions (0.22.1, 0.23.0, 0.23.1) all passed the parse test when tested with older Fusion previews (≤preview.171) that did not error on the default postgres adapter. The package code is unchanged in this regard — this is a false positive from the test harness upgrade to preview.178.