### PR TITLE
Remove dbt_constraints v1.0.8 from Fusion compatible package versions

### DIFF
--- a/data/packages/Snowflake-Labs/dbt_constraints/versions/1.0.8.json
+++ b/data/packages/Snowflake-Labs/dbt_constraints/versions/1.0.8.json
@@ -29,7 +29,7 @@
             "warnings": [],
             "fusion_version": "2.0.0-preview.183"
         },
-        "manually_verified_compatible": true,
+        "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
         "fusion_compatible_download": {}

--- a/data/packages/Snowflake-Labs/dbt_constraints/versions/1.0.9.json
+++ b/data/packages/Snowflake-Labs/dbt_constraints/versions/1.0.9.json
@@ -29,8 +29,8 @@
             "warnings": [],
             "fusion_version": "2.0.0-preview.183"
         },
-        "manually_verified_compatible": false,
-        "manually_verified_incompatible": true,
+        "manually_verified_compatible": true,
+        "manually_verified_incompatible": false,
         "download_failed": false,
         "fusion_compatible_download": {}
     }


### PR DESCRIPTION
v1.0.8 is supposed to be Fusion compatible but it has a bug that was fixed in 1.0.9, so 1.0.8 is moving to incompatible and 1.0.9 is compatible.