### PR TITLE
Mark latest version of dbt_meta_testing as Fusion compatible

### DIFF
--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.4.0.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.4.0.json
@@ -30,7 +30,7 @@
             "fusion_version": "2.0.0-preview.183"
         },
         "manually_verified_compatible": false,
-        "manually_verified_incompatible": true,
+        "manually_verified_incompatible": false,
         "download_failed": false,
         "fusion_compatible_download": {}
     }


### PR DESCRIPTION
Previous versions of dbt_meta_testing were incompatible with dbt v2/Fusion, but this package is compatible starting with version 0.4.0.