### PR TITLE
Add OmerTDK/credit_risk package (v0.1.0)

### DIFF
--- a/data/packages/OmerTDK/credit_risk/index.json
+++ b/data/packages/OmerTDK/credit_risk/index.json
@@ -1,0 +1,9 @@
+{
+    "name": "credit_risk",
+    "namespace": "OmerTDK",
+    "description": "dbt macros for consumer credit risk analytics: roll-rate matrices, vintage curves, CPR/SMM prepayment curves",
+    "latest": "0.1.0",
+    "assets": {
+        "logo": "logos/placeholder.svg"
+    }
+}

--- a/data/packages/OmerTDK/credit_risk/versions/0.1.0.json
+++ b/data/packages/OmerTDK/credit_risk/versions/0.1.0.json
@@ -1,0 +1,21 @@
+{
+    "id": "OmerTDK/credit_risk/0.1.0",
+    "name": "credit_risk",
+    "version": "0.1.0",
+    "published_at": "2026-06-19T00:00:00.000000+00:00",
+    "packages": [],
+    "require_dbt_version": [
+        ">=1.8.0"
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/OmerTDK/dbt-credit-risk/tree/v0.1.0/",
+        "readme": "https://raw.githubusercontent.com/OmerTDK/dbt-credit-risk/v0.1.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/OmerTDK/dbt-credit-risk/tar.gz/v0.1.0",
+        "format": "tgz",
+        "sha1": "be509505ac02a7f9d857b41b4f8c42d0b25d037a"
+    }
+}


### PR DESCRIPTION
# Description
This PR registers a new package: `credit_risk` published by @OmerTDK.

## Package Information
- **Package Name:** credit_risk
- **GitHub Repo:** https://github.com/OmerTDK/dbt-credit-risk
- **Description:** dbt macros for consumer credit risk analytics: roll-rate matrices, vintage curves, CPR/SMM prepayment curves
- **Version:** 0.1.0
- **License:** Apache-2.0

## What it does
Three reusable dbt macros for consumer lending analytics:
- `roll_rate_matrix` — delinquency transition probability matrices
- `vintage_curve` — cohort loss curves over time
- `cpr_smm` — conditional prepayment rate / single monthly mortality

## Verification
- [x] Package has a valid `dbt_project.yml`
- [x] Package has a `README.md` with installation instructions and usage examples
- [x] Initial release tag (`v0.1.0`) exists
- [x] Repository is public
- [x] `require-dbt-version: ">=1.8.0"` is set
- [x] 15 pytest + 15 dbt data tests pass in CI
- [x] Apache-2.0 licensed