### PR TITLE
Emoji rendering support in README

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -26,6 +26,7 @@
     <%= javascript_include_tag 'site' %>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.18/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.6/purify.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -353,10 +353,44 @@ packages:
 </main>
 
 <script>
-  $.get('<%= version._source.readme %>').done(function(data) {
-      document.getElementById('readme').innerHTML = marked.parse(data)
+  fetch('https://api.github.com/emojis')
+    .then(function(r) { return r.json(); })
+    .catch(function() { return {}; })
+    .then(function(emojis) {
+      if (Object.keys(emojis).length > 0) {
+        function emojiChar(url) {
+          var m = url.match(/\/unicode\/([0-9a-f-]+)\.png/i);
+          if (!m) return null;
+          try {
+            return String.fromCodePoint.apply(String, m[1].split('-').map(function(h) { return parseInt(h, 16); }));
+          } catch(e) { return null; }
+        }
 
-  });
+        marked.use({
+          extensions: [{
+            name: 'emoji',
+            level: 'inline',
+            start: function(src) { return src.indexOf(':'); },
+            tokenizer: function(src) {
+              var match = src.match(/^:([a-zA-Z0-9_+\-]+):/);
+              if (match && emojis[match[1]]) {
+                return { type: 'emoji', raw: match[0], name: match[1], url: emojis[match[1]] };
+              }
+            },
+            renderer: function(token) {
+              var ch = emojiChar(token.url);
+              if (ch) return '<span class="emoji" aria-label=":' + token.name + ':">' + ch + '</span>';
+              // Only inject URLs from the expected GitHub CDN origin.
+              if (!/^https:\/\/github\.githubassets\.com\//.test(token.url)) return ':' + token.name + ':';
+              return '<img class="emoji" src="' + token.url + '" alt=":' + token.name + ':" width="20" height="20" />';
+            }
+          }]
+        });
+      }
+      $.get('<%= version._source.readme %>').done(function(data) {
+        document.getElementById('readme').innerHTML = DOMPurify.sanitize(marked.parse(data));
+      });
+    });
   $('#install').each(function(i, block) {
     hljs.highlightBlock(block);
   });

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -380,7 +380,6 @@ packages:
             renderer: function(token) {
               var ch = emojiChar(token.url);
               if (ch) return '<span class="emoji" aria-label=":' + token.name + ':">' + ch + '</span>';
-              // Only inject URLs from the expected GitHub CDN origin.
               if (!/^https:\/\/github\.githubassets\.com\//.test(token.url)) return ':' + token.name + ':';
               return '<img class="emoji" src="' + token.url + '" alt=":' + token.name + ':" width="20" height="20" />';
             }


### PR DESCRIPTION
Resolves #2935 

Confirmed locally this update ensures proper rendering of emojis in GitHub READMEs.
<img width="1183" height="1061" alt="image" src="https://github.com/user-attachments/assets/bd86c9ab-4701-43d7-8f59-9693784e3d8b" />

This update includes the following. Generated with the help of Claude:
- An extension to `https://api.github.com/emojis` which fetches GitHub's emoji map and renders :emoji_name: shortcodes as their native Unicode characters (or <img> tags for non-standard emoji). This brings emoji rendering in READMEs in line with what authors see on GitHub.
- Added DOMPurify (v3.2.6) as a script dependency via CDN.
  - README HTML is now sanitized with DOMPurify.sanitize() before being injected into the DOM.