### PR TITLE
Mark dbt_snowflake_monitoring 5.6.1 as Fusion compatible

### DIFF
--- a/data/packages/get-select/dbt_snowflake_monitoring/versions/5.6.1.json
+++ b/data/packages/get-select/dbt_snowflake_monitoring/versions/5.6.1.json
@@ -45,7 +45,7 @@
             "fusion_version": "2.0.0-preview.183"
         },
         "manually_verified_compatible": false,
-        "manually_verified_incompatible": true,
+        "manually_verified_incompatible": false,
         "download_failed": false,
         "fusion_compatible_download": {}
     }


### PR DESCRIPTION
Marks `get-select/dbt_snowflake_monitoring` 5.6.1 as Fusion compatible (reverses a stale false-negative).

## What this changes

```diff
-        "manually_verified_incompatible": true,
+        "manually_verified_incompatible": false,
```

## Background

`manually_verified_incompatible` was set to `true` in commit 9a33416, as collateral from the postgres-adapter false-negative tracked in #4500. The hub's Fusion check defaulted to a postgres profile, which Fusion rejects (`The 'postgres' adapter is not yet supported`), even though this package is Snowflake-only.

That harness issue has since been resolved — the dependency `get-select/dbt_query_tags` now shows `parse_compatible: true` with no manual override. But this package still carries the stale manual flag, which overrides the passing automated parse result.

## Verification (dbt-fusion 2.0.0-preview.183)

Install the exact engine version the hub used (Mac ARM shown; adjust platform as needed):

```
curl -fsSL "https://public.cdn.getdbt.com/fs/cli/fs-v2.0.0-preview.183-aarch64-apple-darwin.tar.gz" | tar -xz -C /tmp && mv /tmp/dbt /tmp/dbt-183
$ /tmp/dbt-183 --version
dbt-fusion 2.0.0-preview.183
```

`deps` resolves cleanly:

```
$ dbt deps
 Installed get-select/dbt_query_tags: 3.2.0
 Installed dbt-labs/dbt_utils: 1.4.0
 Finished 'deps' successfully
```

`parse` with a **postgres** profile fails — but on the adapter, not the package (this is the harness artifact from #4500):

```
$ dbt parse --profile dbt_snowflake_monitoring   # postgres profile
[error] [InvalidConfig (dbt1005)]: The 'postgres' adapter is not yet supported by dbt Fusion. Supported adapters: snowflake, bigquery, databricks, redshift
```

`parse` with a **snowflake** profile (a supported adapter) succeeds with 0 errors:

```
$ dbt parse --profile dbt_snowflake_monitoring   # snowflake profile
 Finished 'parse' successfully for target 'sf'
```

This matches the automated `parse_compatibility_result` already stored for 5.6.1 (`parse_exit_code: 0`, `total_errors: 0`, `fusion_version: 2.0.0-preview.183`). The package is genuinely Fusion compatible; the only thing marking it otherwise is the stale manual flag this PR reverses.
