### PR TITLE
Correct compatibility for dbt-external-tables v0.12.2

### DIFF
--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.12.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.12.2.json
@@ -32,8 +32,8 @@
             "warnings": [],
             "fusion_version": "2.0.0-preview.183"
         },
-        "manually_verified_compatible": false,
-        "manually_verified_incompatible": true,
+        "manually_verified_compatible": true,
+        "manually_verified_incompatible": false,
         "download_failed": false,
         "fusion_compatible_download": {}
     }


### PR DESCRIPTION
Package is compatible starting with v0.12.0