### PR TITLE
Add v2-compatible versions for dbt-utils 0.6.x

### DIFF
--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.0.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.1.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.2.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.2.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.3.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.3.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.4.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.4.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.5.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.5.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_utils/versions/0.6.6.json
+++ b/data/packages/dbt-labs/dbt_utils/versions/0.6.6.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://codeload.github.com/dbt-labs/dbt-utils/tar.gz/0.7.0",
+            "format": "tgz"
+        }
     }
 }


### PR DESCRIPTION
dbt-utils 0.6.x contains syntax that is incompatible with dbt versions >=0.20.0, which was resolved in dbt-utils 0.7.0. dbt-utils 0.7.0 should otherwise be compatible with dbt v2, so I'm setting the 0.7.0 version as the v2-compatible so dbt deps will substitute those versions when the `--use-v2-compatible-package-downloads` flag is used.