### PR TITLE
Add v2-compatible versions

### DIFF
--- a/data/packages/calogica/dbt_date/versions/0.7.2.json
+++ b/data/packages/calogica/dbt_date/versions/0.7.2.json
@@ -28,6 +28,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_date_0.7.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.1.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.1.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.2.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.2.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.3.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.3.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.4.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.4.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.5.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.5.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.6.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.6.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.7.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.7.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.8.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.8.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.8.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.2.9.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.2.9.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.2.9.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.3.0.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.3.0.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.3.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.3.1.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.3.1.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.3.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.3.2.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.3.2.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.3.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.3.3.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.3.3.json
@@ -62,6 +62,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.3.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/calogica/dbt_expectations/versions/0.3.4.json
+++ b/data/packages/calogica/dbt_expectations/versions/0.3.4.json
@@ -62,6 +62,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_expectations_0.3.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/fivetran/amplitude/versions/v0.1.0.json
+++ b/data/packages/fivetran/amplitude/versions/v0.1.0.json
@@ -56,6 +56,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_amplitude_source_0.1.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/fivetran/facebook_ads/versions/v0.3.0.json
+++ b/data/packages/fivetran/facebook_ads/versions/v0.3.0.json
@@ -181,6 +181,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_facebook_ads_0.3.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/fivetran/facebook_ads/versions/v0.4.0.json
+++ b/data/packages/fivetran/facebook_ads/versions/v0.4.0.json
@@ -182,6 +182,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_facebook_ads_0.4.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/fivetran/facebook_ads/versions/v0.4.1.json
+++ b/data/packages/fivetran/facebook_ads/versions/v0.4.1.json
@@ -182,6 +182,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_facebook_ads_0.4.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/fivetran/intercom/versions/v1.7.0-a1.json
+++ b/data/packages/fivetran/intercom/versions/v1.7.0-a1.json
@@ -27,5 +27,10 @@
         "format": "tgz",
         "sha1": "23fc2d481ed2c0e916b76e401ded58dc23c476cd"
     },
-    "fusion_compatibility": {}
+    "fusion_compatibility": {
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_intercom_1.7.0-a1.tar.gz",
+            "format": "tgz"
+        }
+    }
 }

--- a/data/packages/fivetran/quickbooks/versions/v1.7.0-a1.json
+++ b/data/packages/fivetran/quickbooks/versions/v1.7.0-a1.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/fivetran_quickbooks_1.7.0-a1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/godatadriven/dbt_date/versions/0.1.1.json
+++ b/data/packages/godatadriven/dbt_date/versions/0.1.1.json
@@ -33,6 +33,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": null,
         "download_failed": true,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_date_0.1.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/godatadriven/dbt_date/versions/0.1.2.json
+++ b/data/packages/godatadriven/dbt_date/versions/0.1.2.json
@@ -33,6 +33,9 @@
         "manually_verified_compatible": null,
         "manually_verified_incompatible": null,
         "download_failed": true,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/calogica_dbt_date_0.1.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.1.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.1.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.2.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.2.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.3.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.3.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.4.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.4.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.5.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.5.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.6.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.6.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.7.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.7.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.8.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.8.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.8.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.2.9.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.2.9.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.2.9.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.3.0.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.3.0.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.3.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.3.1.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.3.1.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.3.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.3.2.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.3.2.json
@@ -69,6 +69,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.3.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.3.3.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.3.3.json
@@ -62,6 +62,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.3.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/metaplane/dbt_expectations/versions/0.3.4.json
+++ b/data/packages/metaplane/dbt_expectations/versions/0.3.4.json
@@ -62,6 +62,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/metaplane_dbt_expectations_0.3.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.1.0.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.1.0.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.1.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.1.1.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.1.1.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.1.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.1.2.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.1.2.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.1.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.2.0.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.2.0.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.2.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.2.1.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.2.1.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.2.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.0.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.0.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.1.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.1.json
@@ -50,6 +50,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.2.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.2.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.3.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.3.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.4.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.4.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }


### PR DESCRIPTION
Enable v2-compatible package downloads for additional package versions + fix some cases where the download wasn't correctly populated for some packages with redirects