### PR TITLE
Add v2-compatible versions for verified incompatible versions

### DIFF
--- a/data/packages/brooklyn-data/dbt_artifacts/versions/0.5.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/0.5.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_0.5.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/0.6.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/0.6.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_0.6.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/0.7.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/0.7.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_0.7.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/0.8.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/0.8.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_0.8.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/1.0.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/1.0.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_1.0.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_1.1.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.1.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.1.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_1.1.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.2.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/1.1.2.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_1.1.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/1.2.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/1.2.0.json
@@ -40,6 +40,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_1.2.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.0.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.0.0.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.0.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.1.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.1.0.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.1.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.1.1.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.1.1.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.1.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.0.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.2.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.1.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.1.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.2.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.2.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.2.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.2.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.3.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.2.3.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.2.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.3.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.3.0.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.3.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.4.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.1.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.4.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.2.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.2.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.4.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.3.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.4.3.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.4.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.5.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.5.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.5.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.6.0.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.6.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.6.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/brooklyn-data/dbt_artifacts/versions/2.9.3.json
+++ b/data/packages/brooklyn-data/dbt_artifacts/versions/2.9.3.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/brooklyn-data_dbt_artifacts_2.9.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.10.0-b1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.10.0-b1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.10.0-b1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.10.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.10.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.10.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.10.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.10.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.10.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.11.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.11.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.11.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.11.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.11.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.11.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.12.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.12.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.12.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.12.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.12.2.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.12.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.2.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.2.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.3.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.3.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.4.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.4.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.5.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.5.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.6.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.6.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.8.7.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.8.7.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.8.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.9.0-b1.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.9.0-b1.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.9.0-b1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/dbt-labs/dbt_external_tables/versions/0.9.0.json
+++ b/data/packages/dbt-labs/dbt_external_tables/versions/0.9.0.json
@@ -35,6 +35,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/dbt-labs_dbt_external_tables_0.9.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.5.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.5.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/tnightengale/dbt_meta_testing/versions/0.3.6.json
+++ b/data/packages/tnightengale/dbt_meta_testing/versions/0.3.6.json
@@ -32,6 +32,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": true,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/tnightengale_dbt_meta_testing_0.3.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }


### PR DESCRIPTION
Add v2-compatible package versions for package versions that were verified as incompatible. Previously v2-compatible versions were only added if the package version failed parse.