### PR TITLE
Add v2-compatible downloads from Datavault-UK packages

### DIFF
--- a/data/packages/Datavault-UK/automate_dv/versions/v0.10.0.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.10.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.10.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.10.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.10.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.10.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.10.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.10.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.10.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.11.0.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.11.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.11.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.11.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.11.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.11.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.11.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.11.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.11.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.11.3.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.11.3.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.11.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.11.4.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.11.4.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.11.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.2.1-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.2.1-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.1-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.2.2-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.2.2-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.2-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.2.3-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.2.3-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.3-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.2.4-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.2.4-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.4-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.3.1-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.3.1-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.1-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.3.2-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.3.2-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.2-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.3.3-pre.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.3.3-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.3-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.4.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.4.1.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.4.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.6.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.6.1.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.6.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.6.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.6.2.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.6.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.0.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.0.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.1.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.2.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.3.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.3.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.4.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.4.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.5.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.5.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.6-b1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.6-b1.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.6-b1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.6.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.6.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.7.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.7.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.8.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.8.json
@@ -56,6 +56,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.8.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.7.9.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.7.9.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.9.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.8.0.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.8.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.8.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.8.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.8.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.8.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.8.3.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.8.3.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.0.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.1.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.2.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.3.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.3.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.4.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.4.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.5.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.5.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.6.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.6.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/automate_dv/versions/v0.9.7.json
+++ b/data/packages/Datavault-UK/automate_dv/versions/v0.9.7.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": true,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.2.1-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.2.1-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.1-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.2.2-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.2.2-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.2-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.2.3-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.2.3-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.3-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.2.4-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.2.4-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.2.4-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.3.1-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.3.1-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.1-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.3.2-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.3.2-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.2-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.3.3-pre.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.3.3-pre.json
@@ -45,6 +45,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.3.3-pre.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.4.1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.4.1.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.4.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.6.1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.6.1.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.6.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.6.2.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.6.2.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.6.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.0.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.0.json
@@ -48,6 +48,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.1.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.2.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.2.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.3.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.3.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.4.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.4.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.5.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.5.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.6-b1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.6-b1.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.6-b1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.6.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.6.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.6.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.7.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.7.json
@@ -53,6 +53,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.7.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.8.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.8.json
@@ -56,6 +56,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.8.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.7.9.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.7.9.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.7.9.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.8.0.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.8.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.8.1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.8.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.8.2.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.8.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.8.3.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.8.3.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.8.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.0.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.0.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.0.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.1.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.1.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.1.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.2.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.2.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.2.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.3.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.3.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.3.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.4.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.4.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.4.tar.gz",
+            "format": "tgz"
+        }
     }
 }

--- a/data/packages/Datavault-UK/dbtvault/versions/v0.9.5.json
+++ b/data/packages/Datavault-UK/dbtvault/versions/v0.9.5.json
@@ -43,6 +43,9 @@
         "manually_verified_compatible": false,
         "manually_verified_incompatible": false,
         "download_failed": false,
-        "fusion_compatible_download": {}
+        "fusion_compatible_download": {
+            "tarball": "https://public.cdn.getdbt.com/package-hub/Datavault-UK_automate_dv_0.9.5.tar.gz",
+            "format": "tgz"
+        }
     }
 }


### PR DESCRIPTION
Add autofixed versions for Datavault-UK packages. Note that Datavault-UK/dbtvault was renamed to Datavault-UK/automate_dv, so the v2-compatible download URLs for Datavault-UK/dbtvault reference the updated name.