### PR TITLE
Add scherlok package

### DIFF
--- a/data/packages/rbmuller/scherlok/index.json
+++ b/data/packages/rbmuller/scherlok/index.json
@@ -1,0 +1,9 @@
+{
+    "name": "scherlok",
+    "namespace": "rbmuller",
+    "description": "Zero-config data quality tests for dbt. Statistical anomaly detection with Shewhart control limits.",
+    "latest": "0.9.0",
+    "assets": {
+        "logo": "logos/placeholder.svg"
+    }
+}

--- a/data/packages/rbmuller/scherlok/versions/0.9.0.json
+++ b/data/packages/rbmuller/scherlok/versions/0.9.0.json
@@ -1,0 +1,21 @@
+{
+    "id": "rbmuller/scherlok/0.9.0",
+    "name": "scherlok",
+    "version": "0.9.0",
+    "published_at": "2026-08-10T00:00:00.000000+00:00",
+    "packages": [],
+    "require_dbt_version": [
+        ">=1.6.0",
+        "<2.0.0"
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/rbmuller/scherlok/tree/v0.9.0/",
+        "readme": "https://raw.githubusercontent.com/rbmuller/scherlok/v0.9.0/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/rbmuller/scherlok/tar.gz/v0.9.0",
+        "format": "tgz"
+    }
+}


### PR DESCRIPTION
## New package: scherlok

**Repository:** https://github.com/rbmuller/scherlok  
**Latest version:** 0.9.0  
**License:** MIT

### What it does

Scherlok adds zero-config data quality tests to dbt projects. It includes:

- **4 instant tests** (no setup needed): `not_null_proportion`, `row_count_between`, `recency`, `unique_proportion`
- **2 auto-learning tests** (Shewhart control limits): `volume_anomaly`, `null_anomaly` — backed by incremental metrics models that auto-discover all materialized models

The package is part of the [Scherlok ecosystem](https://github.com/rbmuller/scherlok) — a zero-config data quality monitoring CLI with 5 connectors (Postgres, BigQuery, Snowflake, MySQL, DuckDB), MCP server, and AI-powered alert explanations.

### Checklist

- [x] `dbt_project.yml` at repo root
- [x] Public GitHub repository
- [x] MIT license
- [x] Tagged release (v0.9.0)
- [x] `require-dbt-version: [">=1.6.0", "<2.0.0"]`