### PR TITLE
Remove CMS Chronic Conditions from the package blocklist

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -13,7 +13,6 @@
         "tuva-health/core",
         "tuva-health/chronic_conditions",
         "tuva-health/claims_preprocessing",
-        "tuva-health/cms_chronic_conditions",
         "tuva-health/data_profiling",
         "tuva-health/pmpm",
         "tuva-health/readmissions",


### PR DESCRIPTION
## Summary

Remove tuva-health/cms_chronic_conditions from the dbt Hub blocklist.

The package was intentionally blocklisted in #2497 when Tuva's data marts were consolidated into Tuva Core. Tuva is now restoring CMS Chronic Conditions as an actively maintained standalone package, so the blocklist entry is no longer appropriate.

Package repository: https://github.com/tuva-health/cms_chronic_conditions
Current hardening PR: https://github.com/tuva-health/cms_chronic_conditions/pull/49

## Validation

- parsed data/blocklist.json successfully with Ruby JSON.parse
- git diff --check passed

This PR changes only the blocklist entry.